### PR TITLE
skip processing when after is null for delete operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.residentadvisor.strip_unicode_null_transform</groupId>
     <artifactId>StripUnicodeNullTransform</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <properties>
         <maven.compiler.source>16</maven.compiler.source>

--- a/src/main/java/io/github/residentadvisor/strip_unicode_null_transform/StripUnicodeNullTransform.java
+++ b/src/main/java/io/github/residentadvisor/strip_unicode_null_transform/StripUnicodeNullTransform.java
@@ -21,9 +21,10 @@ public class StripUnicodeNullTransform<R extends ConnectRecord<R>> implements Tr
         for (Field field : struct.schema().fields()) {
             Object value = struct.get(field);
             if (field.name().equals("after")) {
-                Struct after = (Struct) value;
-                Struct newAfter = replaceNullBytes(after);
-                struct.put(field, newAfter);
+                if (value instanceof Struct) {
+                    Struct newAfter = replaceNullBytes((Struct) value);
+                    struct.put(field, newAfter);
+                }
             }
         }
 
@@ -38,6 +39,9 @@ public class StripUnicodeNullTransform<R extends ConnectRecord<R>> implements Tr
     }
     
     private Struct replaceNullBytes(Struct struct) {
+        if (struct == null) {
+            return null;
+        }
         Struct newStruct = new Struct(struct.schema());
         
         for (Field field : struct.schema().fields()) {

--- a/src/test/java/io/github/residentadvisor/strip_unicode_null_transform/StripUnicodeNullTransformTest.java
+++ b/src/test/java/io/github/residentadvisor/strip_unicode_null_transform/StripUnicodeNullTransformTest.java
@@ -104,4 +104,47 @@ public class StripUnicodeNullTransformTest {
                         assertEquals(expectedValue, output.value());
                 }
         }
+
+        @Test
+        public void testTransformWithNullAfterStruct() {
+                try (StripUnicodeNullTransform<SinkRecord> transform = new StripUnicodeNullTransform<>()) {
+                        // Arrange
+                        transform.configure(new HashMap<String, String>());
+
+                        Schema messageSchema = SchemaBuilder.struct()
+                                .field("field1", Schema.STRING_SCHEMA)
+                                .field("field2", Schema.STRING_SCHEMA)
+                                .build();
+
+                        Schema optionalMessageSchema = SchemaBuilder.struct().optional()
+                                .field("field1", Schema.STRING_SCHEMA)
+                                .field("field2", Schema.STRING_SCHEMA)
+                                .build();
+
+                        Schema schema = SchemaBuilder.struct()
+                                .field("before", messageSchema)
+                                .field("after", optionalMessageSchema)
+                                .field("source", Schema.STRING_SCHEMA)
+                                .field("transaction", Schema.STRING_SCHEMA)
+                                .build();
+
+                        Struct inputValue = new Struct(schema)
+                                .put("before", new Struct(messageSchema)
+                                        .put("field1", "foo\u0000bar")
+                                        .put("field2", "baz"))
+                                .put("after", null)
+                                .put("source", "test")
+                                .put("transaction", "test");
+
+                        // Act
+                        SinkRecord output = transform.apply(new SinkRecord("", 0, null, null, schema, inputValue, 0));
+
+                        // Assert
+                        Struct outputValue = (Struct) output.value();
+                        assertNotNull(outputValue);
+                        assertNull(outputValue.get("after"));
+                        assertEquals("foo\u0000bar", ((Struct) outputValue.get("before")).get("field1"));
+                        assertEquals("baz", ((Struct) outputValue.get("before")).get("field2"));
+                }
+        }
 }


### PR DESCRIPTION
### Background :scroll:

Was looking into some ETL debezium stuff and realised when trying to delete something in a source table, I saw [an error](https://app.datadoghq.com/logs?query=service%3Astrimzi%20%22Error%20encountered%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZwWJeihttETSQAAABhBWndXSmUxOUFBREYzY0xHVUtvSDhRQUgAAAAkMTE5YzE2NjItNDM2YS00NDM1LWI5MDYtN2NhNzQ1OTUwZmMzAAS7TQ&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1769874885458&to_ts=1770047685458&live=true) in the strimzi datadog:
<img width="1334" height="97" alt="image" src="https://github.com/user-attachments/assets/021eaec3-5302-4877-b375-d55ec79d1a31" />

I checked and the referenced row was not deleted in the sink table, even though it was in source.

I believe this is because the `after` field is null when the operation type is delete in debezium, which is not handled in this transform, so we get a Java null pointer exception. 

### Changes :memo:

- doesnt try to process null chars when the after field itself is null
- adds test for the null after case